### PR TITLE
Add bulk RARC import support

### DIFF
--- a/gcft_ui/main_window.py
+++ b/gcft_ui/main_window.py
@@ -108,6 +108,8 @@ class GCFTWindow(QMainWindow):
       return (self.gcm_tab.import_gcm_by_path, "GCM ISOs")
     elif file_ext in RARC_FILE_EXTS:
       return (self.rarc_tab.import_rarc_by_path, "RARC Archives")
+    elif os.path.isdir(file_path):
+      return (self.rarc_tab.import_all_rarcs_from_folder, "RARC Archives")
     elif file_ext in BTI_FILE_EXTS:
       return (self.bti_tab.import_bti_by_path, "BTI Images")
     elif file_ext in [".png"]:


### PR DESCRIPTION
Added support for folder-recursive RARC import and unpack in bulk via command line or drag-and-drop, because of my own difficulty in decompiling Twilight Princess' many files. Related to https://github.com/LagoLunatic/GCFT/issues/18.